### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This tap:
     Create a JSON file called `config.json` containing the api key you just generated.
 
     ```json
-    {"api_key": "your-api-token"}
+    {"api_key": "your-api-token", "start_date": "2017-01-01T00:00:00Z"}
     ```
 
 4. [Optional] Create the initial state file


### PR DESCRIPTION
Got this on my first closeio run

```
$ tap-closeio --config ~/configs/closeio.config 
Traceback (most recent call last):
  File "/home/vagrant/.virtualenvs/close-tap/bin/tap-closeio", line 11, in <module>
    sys.exit(main())
  File "/home/vagrant/.virtualenvs/close-tap/local/lib/python3.4/site-packages/tap_closeio/__init__.py", line 181, in main
    config, state = utils.parse_args(REQUIRED_CONFIG_KEYS)
  File "/home/vagrant/.virtualenvs/close-tap/local/lib/python3.4/site-packages/tap_closeio/utils.py", line 56, in parse_args
    check_config(config, required_config_keys)
  File "/home/vagrant/.virtualenvs/close-tap/local/lib/python3.4/site-packages/tap_closeio/utils.py", line 69, in check_config
    raise Exception("Config is missing required keys: {}".format(missing_keys))
Exception: Config is missing required keys: ['start_date']

```