### PR TITLE
Upgrade singer python metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-closeio',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_closeio'],
       install_requires=[
-          'singer-python==1.6.0a2',
+          'singer-python==1.6.0a3',
           'requests==2.12.4',
           'backoff==1.3.2'
       ],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-closeio',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_closeio'],
       install_requires=[
-          'singer-python==1.6.0a3',
+          'singer-python==1.6.0a4',
           'requests==2.12.4',
           'backoff==1.3.2'
       ],

--- a/tap_closeio/__init__.py
+++ b/tap_closeio/__init__.py
@@ -72,7 +72,7 @@ def request(endpoint, params=None):
 
     with metrics.http_request_timer(parse_source_from_url(endpoint)) as timer:
         resp = SESSION.send(req)
-        timer.http_status_code = resp.status_code
+        timer.tags[metrics.Tag.http_status_code] = resp.status_code
         json = resp.json()
 
     # if we're hitting the rate limit cap, sleep until the limit resets

--- a/tap_closeio/__init__.py
+++ b/tap_closeio/__init__.py
@@ -9,7 +9,7 @@ import pendulum
 import requests
 import dateutil.parser
 import singer
-import singer.stats
+import singer.metrics as metrics
 from singer import utils
 
 
@@ -70,12 +70,10 @@ def request(endpoint, params=None):
     req = requests.Request("GET", url, params=params, auth=auth, headers=headers).prepare()
     LOGGER.info("GET {}".format(req.url))
 
-    with singer.stats.Timer(source=parse_source_from_url(endpoint)) as stats:
+    with metrics.http_request_timer(parse_source_from_url(endpoint)) as timer:
         resp = SESSION.send(req)
-        stats.http_status_code = resp.status_code
+        timer.http_status_code = resp.status_code
         json = resp.json()
-        if 'data' in json:
-            stats.record_count = len(json['data'])
 
     # if we're hitting the rate limit cap, sleep until the limit resets
     if resp.headers.get('X-Rate-Limit-Remaining') == "0":
@@ -97,15 +95,18 @@ def gen_request(endpoint, params=None):
     params['_limit'] = PER_PAGE
     params['_skip'] = 0
 
-    while True:
-        body = request(endpoint, params)
-        for row in body['data']:
-            yield row
+    with metrics.record_counter(parse_source_from_url(endpoint)) as counter:
+        while True:
+            body = request(endpoint, params)
+            for row in body['data']:
+                counter.increment()
+                yield row
 
-        if not body.get("has_more"):
-            break
+            if not body.get("has_more"):
+                break
 
-        params['_skip'] += PER_PAGE
+            params['_skip'] += PER_PAGE
+
 
 
 def transform_activity(activity):


### PR DESCRIPTION
Upgrade singer-python to use new metrics format. Here's a sample of the output:

```
INFO METRIC: {"value": 2.5274624824523926, "metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "activity", "status": "succeeded", "http_status_code": 200}}
INFO METRIC: {"value": 3.154313802719116, "metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "activity", "status": "succeeded", "http_status_code": 200}}
INFO METRIC: {"value": 1.674919605255127, "metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "activity", "status": "succeeded", "http_status_code": 200}}
INFO METRIC: {"value": 2.521453619003296, "metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "activity", "status": "succeeded", "http_status_code": 200}}
INFO METRIC: {"value": 2.6671407222747803, "metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "activity", "status": "succeeded", "http_status_code": 200}}
INFO METRIC: {"value": 2201, "metric": "record_count", "type": "counter", "tags": {"endpoint": "activity"}}
INFO METRIC: {"value": 1.8990414142608643, "metric": "http_request_duration", "type": "timer", "tags": {"endpoint": "activity", "status": "succeeded", "http_status_code": 200}}
```