### PR TITLE
Fix/Handle non-standard dates

### DIFF
--- a/tap_closeio/__init__.py
+++ b/tap_closeio/__init__.py
@@ -34,6 +34,14 @@ def transform_datetime(datetime):
     if datetime is None:
         return None
 
+    # It's not documented, but activiy.email.dates can contain a valid date
+    # followed by invalid data, for example (both real examples):
+    #   Fri, 01 Feb 2013 00:54:51 +0000 (UTC)
+    #   Fri, 19 May 2017 10:57:03 +0200 (added by foo@bar.com)
+    #
+    # Get around this by truncating anything beyond the length of the longest valid date:
+    datetime = datetime[:31]
+
     return pendulum.parse(datetime).format(utils.DATETIME_FMT)
 
 


### PR DESCRIPTION
The `activities` endpoint occasionally returns dates as strings with additional data after the date. These cause the date parser to fail. Here are two examples we've come across recently:

- `Fri, 01 Feb 2013 00:54:51 +0000 (UTC)`
- `Fri, 19 May 2017 10:57:03 +0200 (added by foo@bar.com)`

I can't find any documentation of this behavior, and the vast majority of the time, dates are in a standard format. This branch introduces logic to truncate date strings to a maximum of 31 characters, removing any additional characters that aren't valid. 


