### PR TITLE
Fix/Don't attempt to parse envelope__date as a date

### DIFF
--- a/tap_closeio/schemas/activities.json
+++ b/tap_closeio/schemas/activities.json
@@ -69,8 +69,7 @@
           "type": [
             "null",
             "string"
-          ],
-          "format": "date-time"
+          ]
         },
         "subject": {
           "type": [


### PR DESCRIPTION
In #10, I introduced some logic to handle parsing some odd date formats we've been seeing for the CloseIO `evenlope__date` field. We've found an additional odd date format:

```
1/23/17 9:45 AM (GMT-06:00)
```

We've opted to address this by treating this field as a string instead of a date.