### PR TITLE
Window activities by day

### DIFF
--- a/tap_closeio/__init__.py
+++ b/tap_closeio/__init__.py
@@ -133,8 +133,7 @@ def sync_activities():
 
     while start <= now:
         end = start.add(days=1)
-        params = {"date_created__gt": start, "date_created__lt": end}
-        start = start.add(days=1)
+        params = {"date_created__gte": start, "date_created__lt": end}
 
         for row in gen_request("activity/", params):
             transform_activity(row)
@@ -142,8 +141,8 @@ def sync_activities():
             singer.write_record("activities", row)
             utils.update_state(STATE, "activities", dateutil.parser.parse(row['date_created']))
 
+        start = start.add(days=1)
         singer.write_state(STATE)
-
 
 def to_json_type(typ):
     if typ in ["datetime", "date"]:

--- a/tap_closeio/__init__.py
+++ b/tap_closeio/__init__.py
@@ -128,16 +128,21 @@ def sync_activities():
     schema = load_schema("activities")
     singer.write_schema("activities", schema, ["id"])
 
-    start = get_start("activities")
-    params = {"date_created__gt": start}
+    start = pendulum.parse(get_start("activities"))
+    now = pendulum.now()
 
-    for row in gen_request("activity/", params):
-        transform_activity(row)
-        if row['date_created'] >= start:
+    while start <= now:
+        end = start.add(days=1)
+        params = {"date_created__gt": start, "date_created__lt": end}
+        start = start.add(days=1)
+
+        for row in gen_request("activity/", params):
+            transform_activity(row)
+
             singer.write_record("activities", row)
             utils.update_state(STATE, "activities", dateutil.parser.parse(row['date_created']))
 
-    singer.write_state(STATE)
+        singer.write_state(STATE)
 
 
 def to_json_type(typ):


### PR DESCRIPTION
The activities endpoint uses latest first ordering. By simply using the `date_created__gt` param, the tap is limited to writing the Singer state until all the data has been fetched. The change here is to instead use a daily rolling window specified by the appropriate `date_created__gte` and `date_created__lt` values. This provides the opportunity to write a Singer state per day.