### PR TITLE
Rewrite of tap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ ENV/
 env.sh
 config.json
 .autoenv.zsh
+tags

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,8 @@ setup(name='tap-closeio',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_closeio'],
       install_requires=[
-          'singer-python==1.6.0',
+          'singer-python==4.0.2',
           'requests==2.12.4',
-          'backoff==1.3.2'
       ],
       entry_points='''
           [console_scripts]
@@ -20,10 +19,7 @@ setup(name='tap-closeio',
       ''',
       packages=['tap_closeio'],
       package_data = {
-          'tap_closeio/schemas': [
-              'leads.json',
-              'activities.json'
-          ]
+          'schemas': ['tap_closeio/schemas/*.json']
       },
       include_package_data=True,
 )

--- a/tap_closeio/__init__.py
+++ b/tap_closeio/__init__.py
@@ -1,239 +1,76 @@
 #!/usr/bin/env python3
-
 import os
-import time
-import re
-
-import backoff
-import pendulum
-import requests
-import dateutil.parser
+import json
 import singer
-import singer.metrics as metrics
 from singer import utils
-
+from singer.catalog import Catalog, CatalogEntry, Schema
+from . import streams as streams_
+from .context import Context
+from . import schemas
 
 REQUIRED_CONFIG_KEYS = ["start_date", "api_key"]
-PER_PAGE = 100
-BASE_URL = "https://app.close.io/api/v1/"
-
-CONFIG = {}
-STATE = {}
-
 LOGGER = singer.get_logger()
-SESSION = requests.session()
 
 
-def get_abs_path(path):
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
-
-def load_schema(entity):
-    return utils.load_json(get_abs_path("schemas/{}.json".format(entity)))
-
-def transform_datetime(datetime):
-    if datetime is None:
-        return None
-
-    return pendulum.parse(datetime).format(utils.DATETIME_FMT)
-
-
-def transform_datetimes(item, datetime_fields):
-    if not isinstance(datetime_fields, list):
-        datetime_fields = [datetime_fields]
-
-    for k in datetime_fields:
-        if k in item:
-            item[k] = transform_datetime(item[k])
-
-
-def get_start(key):
-    if key not in STATE:
-        STATE[key] = CONFIG['start_date']
-
-    return STATE[key]
-
-
-def parse_source_from_url(url):
-    match = re.match(r'^(\w+)\/', url)
-    if match:
-        return match.group(1)
-
-
-def request(endpoint, params=None):
-    url = BASE_URL + endpoint
-    params = params or {}
-    headers = {}
-    if 'user_agent' in CONFIG:
-        headers['User-Agent'] = CONFIG['user_agent']
-
-    auth = (CONFIG['api_key'], "")
-    req = requests.Request("GET", url, params=params, auth=auth, headers=headers).prepare()
-    LOGGER.info("GET {}".format(req.url))
-
-    with metrics.http_request_timer(parse_source_from_url(endpoint)) as timer:
-        resp = SESSION.send(req)
-        timer.tags[metrics.Tag.http_status_code] = resp.status_code
-        json = resp.json()
-
-    # if we're hitting the rate limit cap, sleep until the limit resets
-    if resp.headers.get('X-Rate-Limit-Remaining') == "0":
-        time.sleep(int(resp.headers['X-Rate-Limit-Reset']))
-
-    # if we're already over the limit, we'll get a 429
-    # sleep for the rate_reset seconds and then retry
-    if resp.status_code == 429:
-        time.sleep(json["rate_reset"])
-        return request(endpoint, params)
-
+def has_access_to_event_log(ctx):
+    request = streams_.create_request(schemas.IDS.EVENT_LOG)
+    resp = ctx.client.prepare_and_send(request)
+    if resp.status_code == 400:
+        return False
     resp.raise_for_status()
-
-    return json
-
-
-def gen_request(endpoint, params=None):
-    params = params or {}
-    params['_limit'] = PER_PAGE
-    params['_skip'] = 0
-
-    with metrics.record_counter(parse_source_from_url(endpoint)) as counter:
-        while True:
-            body = request(endpoint, params)
-            for row in body['data']:
-                counter.increment()
-                yield row
-
-            if not body.get("has_more"):
-                break
-
-            params['_skip'] += PER_PAGE
+    return True
 
 
-
-def transform_activity(activity):
-    transform_datetimes(activity, ["date_scheduled"])
-
-    # activity["envelope"]["date"] has many different formats, some of which
-    # aren't recognized by pendulum. For this reason, we treat this field as a
-    # string. Examples:
-    # - Fri, 01 Feb 2013 00:54:51 +0000 (UTC)
-    # - Fri, 19 May 2017 10:57:03 +0200 (added by foo@bar.com)
-    # - 4/21/17 9:21 AM (GMT-05:00)
-
-    if "send_attempts" in activity:
-        for item in activity["send_attempts"]:
-            transform_datetimes(item, ["date"])
-
-
-def sync_activities():
-    schema = load_schema("activities")
-    singer.write_schema("activities", schema, ["id"])
-
-    start = pendulum.parse(get_start("activities"))
-    now = pendulum.now()
-
-    while start <= now:
-        end = start.add(days=1)
-        params = {"date_created__gte": start, "date_created__lt": end}
-
-        for row in gen_request("activity/", params):
-            transform_activity(row)
-
-            singer.write_record("activities", row)
-            utils.update_state(STATE, "activities", dateutil.parser.parse(row['date_created']))
-
-        start = start.add(days=1)
-        singer.write_state(STATE)
-
-def to_json_type(typ):
-    if typ in ["datetime", "date"]:
-        return {"type": ["null", "string"], "format": "date-time"}
-
-    if typ == "number":
-        return {"type": ["null", "number", "boolean"]}
-
-    # According to the closeio docs on choices:
-    # "Choices: a dropdown of predefined choices. Admins can set up all the possible
-    # choices this field can contain ahead of time."
-    # closeio docs on user:
-    # "User: a dropdown containing all the users who are active in your organization."
-    if typ in ["text", "choices", "user"]:
-        return {"type": ["null", "string", "boolean"]}
-
-    # According to the closeio docs on hidden:
-    # "Hidden: a field that's never displayed in the UI, but can be useful for API integrations.
-    # Accepts any data type from JSON, including lists and objects."
-    if typ == 'hidden':
-        return {}
-
-    raise ValueError('Unexpected custom field type: {}'.format(typ))
+def discover(ctx):
+    use_event_log = has_access_to_event_log(ctx)
+    catalog = Catalog([])
+    for tap_stream_id in streams_.stream_ids:
+        if not use_event_log and tap_stream_id == schemas.IDS.EVENT_LOG:
+            continue
+        schema = Schema.from_dict(schemas.load_schema(ctx, tap_stream_id),
+                                  inclusion="automatic")
+        catalog.streams.append(CatalogEntry(
+            stream=tap_stream_id,
+            tap_stream_id=tap_stream_id,
+            key_properties=schemas.PK_FIELDS[tap_stream_id],
+            schema=schema,
+        ))
+    return catalog
 
 
-def get_custom_leads_schema():
-    return {
-        "type": "object",
-        "properties": {row["name"]: to_json_type(row["type"])
-                       for row in gen_request("custom_fields/lead/")},
-    }
-
-
-def transform_lead(lead, custom_schema):
-    if "tasks" in lead:
-        for item in lead["tasks"]:
-            transform_datetimes(item, ["date", "due_date"])
-
-    if "opportunities" in lead:
-        for item in lead["opportunities"]:
-            transform_datetimes(item, ["date_won"])
-
-    if "custom" in lead:
-        custom_datetimes = [k for k, v in custom_schema["properties"].items()
-                            if v.get("format") == "date-time"]
-        transform_datetimes(lead["custom"], custom_datetimes)
-
-
-def sync_leads():
-    schema = load_schema("leads")
-    custom_schema = get_custom_leads_schema()
-    schema["properties"]["custom"] = custom_schema
-    singer.write_schema("leads", schema, ["id"])
-
-    start = get_start("leads")
-    formatted_start = dateutil.parser.parse(start).strftime("%Y-%m-%d %H:%M")
-    params = {'query': 'date_updated>="{}" sort:date_updated'.format(formatted_start)}
-
-    for i, row in enumerate(gen_request("lead/", params)):
-        transform_lead(row, custom_schema)
-        row['contacts'] = [request("contact/{}/".format(contact['id']))
-                           for contact in row['contacts']]
-        if row['date_updated'] >= start:
-            singer.write_record("leads", row)
-            utils.update_state(STATE, "leads", dateutil.parser.parse(row['date_updated']))
-
-        if i % PER_PAGE == 0:
-            singer.write_state(STATE)
-
-    singer.write_state(STATE)
-
-
-def do_sync():
-    LOGGER.info("Starting sync")
-    # sync_activities()
-    sync_leads()
-    LOGGER.info("Completed sync")
+def sync(ctx):
+    currently_syncing = ctx.state.get("currently_syncing")
+    start_idx = streams_.stream_ids.index(currently_syncing) \
+        if currently_syncing else 0
+    streams = [s for s in streams_.streams[start_idx:]
+               if s.tap_stream_id in ctx.selected_stream_ids]
+    for stream in streams:
+        ctx.state["currently_syncing"] = stream.tap_stream_id
+        ctx.write_state()
+        schemas.load_and_write_schema(ctx, stream.tap_stream_id)
+        stream.sync_fn(ctx)
+    ctx.state["currently_syncing"] = None
+    ctx.write_state()
 
 
 def main_impl():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
-    CONFIG.update(args.config)
-    STATE.update(args.state)
-    do_sync()
+    ctx = Context(args.config, args.state)
+    if args.discover:
+        discover(ctx).dump()
+        print()
+    else:
+        ctx.catalog = Catalog.from_dict(args.properties) \
+            if args.properties else discover(ctx)
+        sync(ctx)
+
 
 def main():
     try:
         main_impl()
     except Exception as exc:
         LOGGER.critical(exc)
-        raise exc
+        raise
 
 if __name__ == "__main__":
     main()

--- a/tap_closeio/context.py
+++ b/tap_closeio/context.py
@@ -1,0 +1,65 @@
+import singer
+from singer import bookmarks as bks_
+from .http import Client
+from .transform import find_dt_paths
+
+
+class Context(object):
+    """Represents a collection of global objects necessary for performing
+    discovery or for running syncs. Notably, it contains
+
+    - config  - The JSON structure from the config.json argument
+    - state   - The mutable state dict that is shared among streams
+    - client  - An HTTP client object for interacting with Close.io
+    - catalog - A singer.catalog.Catalog. Note this will be None during
+                discovery.
+    """
+    def __init__(self, config, state):
+        self.config = config
+        self.state = state
+        self.client = Client(config)
+        self._catalog = None
+        self.selected_stream_ids = None
+        self.schema_dt_paths = None
+
+    @property
+    def catalog(self):
+        return self._catalog
+
+    @catalog.setter
+    def catalog(self, catalog):
+        self._catalog = catalog
+        self.selected_stream_ids = set(
+            [s.tap_stream_id for s in catalog.streams
+             if s.is_selected()]
+        )
+        self.schema_dt_paths = {
+            stream.tap_stream_id: find_dt_paths(stream.schema)
+            for stream in catalog.streams
+        }
+
+    def get_bookmark(self, path):
+        return bks_.get_bookmark(self.state, *path)
+
+    def set_bookmark(self, path, val):
+        bks_.write_bookmark(self.state, path[0], path[1], val)
+
+    def get_offset(self, path):
+        off = bks_.get_offset(self.state, path[0])
+        return (off or {}).get(path[1])
+
+    def set_offset(self, path, val):
+        bks_.set_offset(self.state, path[0], path[1], val)
+
+    def clear_offsets(self, tap_stream_id):
+        bks_.clear_offset(self.state, tap_stream_id)
+
+    def update_start_date_bookmark(self, path):
+        val = self.get_bookmark(path)
+        if not val:
+            val = self.config["start_date"]
+            self.set_bookmark(path, val)
+        return val
+
+    def write_state(self):
+        singer.write_state(self.state)

--- a/tap_closeio/http.py
+++ b/tap_closeio/http.py
@@ -1,0 +1,68 @@
+import time
+from collections import namedtuple
+import requests
+from requests.auth import HTTPBasicAuth
+from singer import metrics
+
+BASE_URL = "https://app.close.io/api/v1"
+PER_PAGE = 100
+
+
+class RateLimitException(Exception):
+    pass
+
+
+def _join(a, b):
+    return a.rstrip("/") + "/" + b.lstrip("/")
+
+
+def url(path):
+    return _join(BASE_URL, path)
+
+
+def create_get_request(path, **kwargs):
+    return requests.Request(method="GET", url=url(path), **kwargs)
+
+
+class Client(object):
+    def __init__(self, config):
+        self.user_agent = config.get("user_agent")
+        self.session = requests.Session()
+        self.auth = HTTPBasicAuth(config["api_key"], "")
+
+    def prepare_and_send(self, request):
+        if self.user_agent:
+            request.headers["User-Agent"] = self.user_agent
+        request.auth = self.auth
+        return self.session.send(request.prepare())
+
+    def request_with_handling(self, tap_stream_id, request):
+        with metrics.http_request_timer(tap_stream_id) as timer:
+            resp = self.prepare_and_send(request)
+            timer.tags[metrics.Tag.http_status_code] = resp.status_code
+        json = resp.json()
+        # if we're hitting the rate limit cap, sleep until the limit resets
+        if resp.headers.get('X-Rate-Limit-Remaining') == "0":
+            time.sleep(int(resp.headers['X-Rate-Limit-Reset']))
+        # if we're already over the limit, we'll get a 429
+        # sleep for the rate_reset seconds and then retry
+        if resp.status_code == 429:
+            time.sleep(json["rate_reset"])
+            return self.request_with_handling(tap_stream_id, request)
+        resp.raise_for_status()
+        return json
+
+Page = namedtuple("Page", ("records", "skip", "next_skip"))
+
+
+def paginate(client, tap_stream_id, request, *, skip=0):
+    request.params = request.params or {}
+    request.params["_limit"] = PER_PAGE
+    while True:
+        request.params["_skip"] = skip
+        response = client.request_with_handling(tap_stream_id, request)
+        next_skip = skip + len(response["data"])
+        yield Page(response["data"], skip, next_skip)
+        if not response.get("has_more"):
+            break
+        skip = next_skip

--- a/tap_closeio/schemas.py
+++ b/tap_closeio/schemas.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import os
+import singer
+from singer import utils
+
+
+class IDS(object):
+    CUSTOM_FIELDS = "custom_fields"
+    LEADS = "leads"
+    ACTIVITIES = "activities"
+    TASKS = "tasks"
+    USERS = "users"
+    EVENT_LOG = "event_log"
+
+PK_FIELDS = {
+    IDS.CUSTOM_FIELDS: ["id"],
+    IDS.LEADS: ["id"],
+    IDS.ACTIVITIES: ["id"],
+    IDS.TASKS: ["id"],
+    IDS.USERS: ["id"],
+    IDS.EVENT_LOG: ["id"],
+}
+
+
+def get_abs_path(path):
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
+
+
+def load_schema(ctx, tap_stream_id):
+    path = "schemas/{}.json".format(tap_stream_id)
+    schema = utils.load_json(get_abs_path(path))
+    dependencies = schema.pop("tap_schema_dependencies", [])
+    refs = {}
+    for sub_stream_id in dependencies:
+        refs[sub_stream_id] = load_schema(ctx, sub_stream_id)
+    if refs:
+        singer.resolve_schema_references(schema, refs)
+    return schema
+
+
+def load_and_write_schema(ctx, tap_stream_id):
+    schema = load_schema(ctx, tap_stream_id)
+    singer.write_schema(tap_stream_id, schema, PK_FIELDS[tap_stream_id])

--- a/tap_closeio/schemas/activities.json
+++ b/tap_closeio/schemas/activities.json
@@ -30,7 +30,8 @@
                   "string"
                 ]
               }
-            }
+            },
+            "additionalProperties": false
           }
         },
         "message_id": {
@@ -62,14 +63,16 @@
                   "string"
                 ]
               }
-            }
+            },
+            "additionalProperties": false
           }
         },
         "date": {
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "date-time"
         },
         "subject": {
           "type": [
@@ -107,7 +110,8 @@
                   "string"
                 ]
               }
-            }
+            },
+            "additionalProperties": false
           }
         },
         "bcc": {
@@ -133,7 +137,8 @@
                   "string"
                 ]
               }
-            }
+            },
+            "additionalProperties": false
           }
         },
         "reply_to": {
@@ -159,7 +164,8 @@
                   "string"
                 ]
               }
-            }
+            },
+            "additionalProperties": false
           }
         },
         "to": {
@@ -185,7 +191,8 @@
                   "string"
                 ]
               }
-            }
+            },
+            "additionalProperties": false
           }
         },
         "in_reply_to": {
@@ -194,7 +201,8 @@
             "string"
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "date_created": {
       "type": [
@@ -239,7 +247,8 @@
               "string"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "need_smtp_credentials": {
@@ -269,8 +278,8 @@
     },
     "transferred_from": {
       "type": [
-          "null",
-          "string"
+        "null",
+        "string"
       ]
     },
     "user_id": {
@@ -380,7 +389,8 @@
               "string"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "message_ids": {
@@ -431,7 +441,8 @@
               "boolean"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "opens": {
@@ -469,7 +480,8 @@
               "string"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "task_id": {
@@ -763,10 +775,17 @@
               "string"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "dialer_id": {
       "type": [
         "null",
         "string"
@@ -777,6 +796,19 @@
         "null",
         "string"
       ]
+    },
+    "users": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "$ref": "users"
+      }
     }
-  }
+  },
+  "additionalProperties": false,
+  "tap_schema_dependencies": [
+    "users"
+  ]
 }

--- a/tap_closeio/schemas/custom_fields.json
+++ b/tap_closeio/schemas/custom_fields.json
@@ -1,0 +1,59 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "date_created": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "date_updated": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "created_by": {
+      "type": "string"
+    },
+    "updated_by": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "organization_id": {
+      "type": "string"
+    },
+    "choices": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "editable_with_roles": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tap_closeio/schemas/event_log.json
+++ b/tap_closeio/schemas/event_log.json
@@ -1,0 +1,116 @@
+{
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "date_updated": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "action": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_created": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "data": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "previous_data": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "object_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "user_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "lead_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "request_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "object_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "organization_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "changed_fields": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "meta": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "request_path": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "request_method": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/tap_closeio/schemas/integration_links.json
+++ b/tap_closeio/schemas/integration_links.json
@@ -1,0 +1,27 @@
+{
+  "type": [
+    "null",
+    "array"
+  ],
+  "items": {
+    "type": [
+      "null",
+      "object"
+    ],
+    "properties": {
+      "name": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "url": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/tap_closeio/schemas/leads.json
+++ b/tap_closeio/schemas/leads.json
@@ -1,31 +1,28 @@
 {
   "type": "object",
   "properties": {
-    "integration_links": {
-      "type": [
-        "null",
-        "array"
-      ],
+    "custom_fields": {
+      "type": "array",
       "items": {
-        "type": [
-          "null",
-          "object"
-        ],
+        "type": "object",
         "properties": {
-          "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+          "id": {
+            "type": "string"
           },
-          "url": {
+          "value": {
             "type": [
               "null",
-              "string"
+              "string",
+              "number",
+              "boolean"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
+    },
+    "integration_links": {
+      "$ref": "integration_links"
     },
     "description": {
       "type": [
@@ -56,6 +53,9 @@
           "object"
         ],
         "properties": {
+          "integration_links": {
+            "$ref": "integration_links"
+          },
           "value": {
             "type": [
               "null",
@@ -210,7 +210,8 @@
             ],
             "format": "date-time"
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "organization_id": {
@@ -332,7 +333,8 @@
           },
           "contact_name": {
             "type": [
-              "null"
+              "null",
+              "string"
             ]
           },
           "assigned_to": {
@@ -375,7 +377,8 @@
           },
           "contact_id": {
             "type": [
-              "null"
+              "null",
+              "string"
             ]
           },
           "is_complete": {
@@ -385,7 +388,8 @@
               "boolean"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "status_label": {
@@ -418,6 +422,24 @@
           "object"
         ],
         "properties": {
+          "urls": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
           "title": {
             "type": [
               "null",
@@ -425,30 +447,7 @@
             ]
           },
           "integration_links": {
-            "type": [
-              "null",
-              "array"
-            ],
-            "items": {
-              "type": [
-                "null",
-                "object"
-              ],
-              "properties": {
-                "name": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                "url": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                }
-              }
-            }
+            "$ref": "integration_links"
           },
           "id": {
             "type": [
@@ -491,7 +490,8 @@
                     "string"
                   ]
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "lead_id": {
@@ -548,7 +548,8 @@
                     "string"
                   ]
                 }
-              }
+              },
+              "additionalProperties": false
             }
           },
           "date_created": {
@@ -558,7 +559,8 @@
             ],
             "format": "date-time"
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "updated_by_name": {
@@ -638,7 +640,8 @@
               "string"
             ]
           }
-        }
+        },
+        "additionalProperties": false
       }
     },
     "name": {
@@ -653,5 +656,9 @@
         "string"
       ]
     }
-  }
+  },
+  "additionalProperties": false,
+  "tap_schema_dependencies": [
+    "integration_links"
+  ]
 }

--- a/tap_closeio/schemas/tasks.json
+++ b/tap_closeio/schemas/tasks.json
@@ -1,0 +1,270 @@
+{
+  "properties": {
+    "emails": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
+    "date": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "voicemail_duration": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "body_preview": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "created_by": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "organization_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "phone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "phone_formatted": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "assigned_to": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "is_complete": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "object_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "lead_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "view": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_updated": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "is_dateless": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "updated_by_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "updated_by": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "remote_phone_description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "text": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "contact_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "assigned_to_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "opportunity_value_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "opportunity_value": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "remote_phone_formatted": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "contact_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "lead_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "opportunity_value_formatted": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "phone_number_description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_created": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "due_date": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "opportunity_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "remote_phone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "subject": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "recording_url": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "object_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "created_by_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "voicemail_url": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "opportunity_value_period": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "id": {
+      "type": [
+        "string"
+      ]
+    },
+    "email_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "local_phone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  },
+  "type": [
+    "null",
+    "object"
+  ],
+  "additionalProperties": false
+}

--- a/tap_closeio/schemas/users.json
+++ b/tap_closeio/schemas/users.json
@@ -1,0 +1,71 @@
+{
+  "additionalProperties": false,
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "first_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "organizations": {
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "type": [
+        "null",
+        "array"
+      ]
+    },
+    "email": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_updated": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "last_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "image": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_created": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "date-time"
+    },
+    "last_used_timezone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  }
+}

--- a/tap_closeio/streams.py
+++ b/tap_closeio/streams.py
@@ -1,0 +1,171 @@
+import json
+from datetime import datetime, timedelta, timezone
+from collections import namedtuple
+from functools import partial
+import pendulum
+import singer
+from singer.utils import strftime
+from .http import paginate, create_get_request
+from .transform import transform_dts, format_leads
+from .schemas import IDS
+
+LOGGER = singer.get_logger()
+
+PATHS = {
+    IDS.CUSTOM_FIELDS: "/custom_fields/lead/",
+    IDS.LEADS: "/lead/",
+    IDS.ACTIVITIES: "/activity/",
+    IDS.TASKS: "/task/",
+    IDS.USERS: "/user/",
+    IDS.EVENT_LOG: "/event/",
+}
+
+Stream = namedtuple("Stream", ["tap_stream_id", "sync_fn"])
+
+BOOK_KEYS = {
+    IDS.CUSTOM_FIELDS: "date_updated",
+    IDS.LEADS: "date_updated",
+    IDS.ACTIVITIES: "date_created",
+    IDS.TASKS: "date_updated",
+    IDS.USERS: "date_updated",
+    IDS.EVENT_LOG: "date_updated",
+}
+
+FORMATTERS = {
+    IDS.LEADS: format_leads,
+}
+
+
+def bookmark(tap_stream_id):
+    return [tap_stream_id, BOOK_KEYS[tap_stream_id]]
+
+
+def new_max_bookmark(max_bookmark, records, key):
+    for record in records:
+        if record[key] > max_bookmark:
+            max_bookmark = record[key]
+    return max_bookmark
+
+
+def format_dts(tap_stream_id, ctx, records):
+    paths = ctx.schema_dt_paths[tap_stream_id]
+    return transform_dts(records, paths)
+
+
+def metrics(tap_stream_id, page):
+    with singer.metrics.record_counter(tap_stream_id) as counter:
+        counter.increment(len(page))
+
+
+def write_records(tap_stream_id, page):
+    singer.write_records(tap_stream_id, page)
+    metrics(tap_stream_id, page)
+
+
+def paginated_sync(tap_stream_id, ctx, request, start_date):
+    bookmark_key = BOOK_KEYS[tap_stream_id]
+    offset = [tap_stream_id, "skip"]
+    skip = ctx.get_offset(offset) or 0
+    max_bookmark = start_date
+    formatter = FORMATTERS.get(tap_stream_id, (lambda x: x))
+    for page in paginate(ctx.client, tap_stream_id, request, skip=skip):
+        records = formatter(format_dts(tap_stream_id, ctx, page.records))
+        to_write = [rec for rec in records if rec[bookmark_key] >= start_date]
+        max_bookmark = new_max_bookmark(max_bookmark, records, bookmark_key)
+        write_records(tap_stream_id, to_write)
+        ctx.set_offset(offset, page.next_skip)
+        ctx.write_state()
+    ctx.clear_offsets(tap_stream_id)
+    ctx.set_bookmark(bookmark(tap_stream_id), max_bookmark)
+    ctx.write_state()
+
+
+def create_request(tap_stream_id, params=None):
+    params = params or {}
+    return create_get_request(PATHS[tap_stream_id], params=params)
+
+
+def fetch_all(tap_stream_id, ctx):
+    """Does a basic, paginated request to this stream's path and returns
+    all records from all pages."""
+    request = create_request(tap_stream_id)
+    records = []
+    for page in paginate(ctx.client, tap_stream_id, request):
+        records += page.records
+    return records
+
+
+def basic_paginator(tap_stream_id, ctx):
+    request = create_request(tap_stream_id)
+    start_date = ctx.update_start_date_bookmark(bookmark(tap_stream_id))
+    paginated_sync(tap_stream_id, ctx, request, start_date)
+
+
+def sync_leads(ctx):
+    start_date = ctx.update_start_date_bookmark(bookmark(IDS.LEADS))
+    # date_updated>= has precision to the minute
+    formatted_start = pendulum.parse(start_date).strftime("%Y-%m-%dT%H:%M")
+    query = 'date_updated>="{}" sort:date_updated'.format(formatted_start)
+    request = create_request(IDS.LEADS, params={"query": query})
+    paginated_sync(IDS.LEADS, ctx, request, start_date)
+
+
+def sync_activities(ctx):
+    start_date_str = ctx.update_start_date_bookmark(bookmark(IDS.ACTIVITIES))
+    start_date = pendulum.parse(start_date_str)
+    offset_secs = ctx.config.get("activities_window_seconds", 0)
+    start_date -= timedelta(seconds=offset_secs)
+    # date_created__gt has precision to the second
+    formatted_start = start_date.strftime("%Y-%m-%dT%H:%M:%S")
+    params = {"date_created__gt": formatted_start}
+    request = create_request(IDS.ACTIVITIES, params=params)
+    paginated_sync(IDS.ACTIVITIES, ctx, request, formatted_start)
+
+
+def sync_event_log(ctx):
+    start_date = ctx.update_start_date_bookmark(bookmark(IDS.EVENT_LOG))
+    # date_updated__gt has sub-second precision, but truncate to the second
+    # just to be sure
+    formatted_start = pendulum.parse(start_date).strftime("%Y-%m-%dT%H:%M:%S")
+    max_bookmark = start_date
+    cursor_next = None
+    while True:
+        params = {"date_updated__gte": formatted_start}
+        if cursor_next:
+            params["_cursor"] = cursor_next
+        request = create_request(IDS.EVENT_LOG, params)
+        response = ctx.client.request_with_handling(IDS.EVENT_LOG, request)
+        if not response["data"]:
+            break
+        events = format_dts(IDS.EVENT_LOG, ctx, response["data"])
+        for event in events:
+            event["data"] = json.dumps(event["data"])
+            event["previous_data"] = json.dumps(event["previous_data"])
+        write_records(IDS.EVENT_LOG, events)
+        max_bookmark = new_max_bookmark(max_bookmark, events, "date_updated")
+        cursor_next = response["cursor_next"]
+        if not cursor_next:
+            break
+    # The Close.io docs indicate:
+    # > To avoid missing recent events when paginating, we recommend to
+    # > scan the latest five minutes of events.
+    # Therefore we do not set the bookmark to any value that is in the last
+    # five minutes.
+    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    five_minutes_ago = strftime(now - timedelta(minutes=5))
+    max_bookmark = min(five_minutes_ago, max_bookmark)
+    ctx.set_bookmark(bookmark(IDS.EVENT_LOG), max_bookmark)
+
+
+def mk_basic_paginator(tap_stream_id):
+    return Stream(tap_stream_id, partial(basic_paginator, tap_stream_id))
+
+streams = [
+    mk_basic_paginator(IDS.CUSTOM_FIELDS),
+    Stream(IDS.LEADS, sync_leads),
+    Stream(IDS.ACTIVITIES, sync_activities),
+    mk_basic_paginator(IDS.TASKS),
+    mk_basic_paginator(IDS.USERS),
+    Stream(IDS.EVENT_LOG, sync_event_log),
+]
+stream_ids = [s.tap_stream_id for s in streams]

--- a/tap_closeio/transform.py
+++ b/tap_closeio/transform.py
@@ -1,0 +1,116 @@
+import pendulum
+from singer.utils import strftime
+
+
+class _PathItem(object):
+    def iterate(self, item):
+        raise NotImplementedError()
+
+
+class DictKey(_PathItem):
+    expected_type = dict
+    def __init__(self, key):
+        self.key = key
+    def __repr__(self):
+        return "<DictKey({})>".format(self.key)
+    def __eq__(self, other):
+        return self.key == other.key
+    def iterate(self, item):
+        yield self.key, item.get(self.key)
+
+
+class _ListItems(_PathItem):
+    expected_type = list
+    def __repr__(self):
+        return "<ListItems>"
+    def iterate(self, item):
+        for i, v in enumerate(item):
+            yield i, v
+
+ListItems = _ListItems()
+
+
+def find_dt_paths(schema, path=None):
+    """Given a schema, recursively finds all keys with a date-time format.
+
+    Returns a list of lists, where each inner list represents the path in a
+    record where a date-time would be found. For example, if the path were
+
+        [DictKey("foo"), ListItems, DictKey("bar")]
+
+    Then for a record matching this schema, a date-time value could be found
+    with:
+
+        record["foo"][0]["bar"]
+
+    Note that ListItems is used to indicate there will be a list, rather than a
+    dict. Hence if the path were
+
+        [ListItems]
+
+    This means that all items inside the list are date-times."""
+    path = path or []
+    found = []
+    if schema.format == "date-time":
+        found.append(path)
+    elif schema.properties:
+        for k, v in schema.properties.items():
+            found += find_dt_paths(v, path + [DictKey(k)])
+    elif schema.items:
+        found += find_dt_paths(schema.items, path + [ListItems])
+    return found
+
+
+class TransformationException(Exception):
+    def __init__(self, item, path, path_idx):
+        super().__init__(
+            "Unexpected type found. path {}; path_idx {}; actual type {};"
+            .format(path, path_idx, type(item))
+        )
+
+def _check_type(item, path, path_idx):
+    path_item = path[path_idx]
+    if not isinstance(item, path_item.expected_type):
+        raise TransformationException(item, path, path_idx)
+
+
+def _transform_impl(item, path, path_idx=0):
+    if not item:
+        return item
+    if path_idx == len(path):
+        dt = pendulum.parse(item).in_timezone("UTC")
+        return strftime(dt)
+    _check_type(item, path, path_idx)
+    path_item = path[path_idx]
+    for k, v in path_item.iterate(item):
+        if not v:
+            continue
+        item[k] = _transform_impl(v, path, path_idx + 1)
+    return item
+
+
+def transform_dts(records, paths):
+    """Accepts a list of records and a list of paths and re-formats all
+    date-times to RFC3339.
+
+    `paths` is a list as output by the `find_dt_paths` function."""
+    for path in paths:
+        _transform_impl(records, [ListItems] + path)
+    return records
+
+
+def format_leads(leads):
+    """For a list of leads, removes the "custom" key from each lead and
+    transforms all "custom.* fields into a new "custom_fields" list."""
+    new_leads = []
+    for lead in leads:
+        custom_fields = []
+        new_lead = {"custom_fields": custom_fields}
+        for k, v in lead.items():
+            if k.startswith("custom."):
+                custom_id = k.split(".")[1]
+                custom_fields.append({"id": custom_id, "value": v})
+            elif k != "custom":
+                new_lead[k] = v
+        new_leads.append(new_lead)
+    return new_leads


### PR DESCRIPTION
Primarily to:

- Begin syncing new streams
- Bring the tap up-to-date with latest practices

Details:

- Discovery mode is updated to all the latest practices, like usage of `inclusion`
- The JSON schemas have been updated to use `additionalProperties: false` everywhere
- New streams have been added:
  - Custom fields
  - Event log
  - Tasks
  - Users
- tap-tester tests created https://github.com/stitchdata/tap-tester/pull/25
- Project structure has been revamped to split functionality up

To test this I:

- Ran the tap and synced into Redshift (data from a test account)
- Briefly looked through Redshift tables to check structure
- Created and ran tap-tester tests
- Used https://github.com/b-ryan/singer-best-practices-linter

