### PR TITLE
Bump read timeout slightly

### DIFF
--- a/tap_closeio/http.py
+++ b/tap_closeio/http.py
@@ -36,7 +36,9 @@ class Client(object):
         if self.user_agent:
             request.headers["User-Agent"] = self.user_agent
         request.auth = self.auth
-        return self.session.send(request.prepare(), timeout=5.0)
+        # This timeout was increased from 5 to 10 after receiving errors
+        # that were being retried erroneously: requests.exceptions.ReadTimeout
+        return self.session.send(request.prepare(), timeout=10.0)
 
     @utils.backoff((requests.exceptions.RequestException), utils.exception_is_4xx)
     def request_with_handling(self, tap_stream_id, request):


### PR DESCRIPTION
There was an issue of infinite looping because the backoff code would retry an error:

```
*** requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='close.io', port=443): Read timed out. (read timeout=5.0)
```

