### PR TITLE
TDL-12048: Ignore Future dated activities

### DIFF
--- a/tap_closeio/streams.py
+++ b/tap_closeio/streams.py
@@ -161,6 +161,8 @@ def sync_leads(ctx):
 def sync_activities(ctx):
     start_date_str = ctx.update_start_date_bookmark(bookmark(IDS.ACTIVITIES))
     start_date = pendulum.parse(start_date_str)
+    # select current datetime as end_date
+    end_date = singer.utils.now().isoformat()
     # 24 hours of activities essentially allows us to capture updates to
     # calls that are in progress _while_ an extraction is happening, no
     # matter the replication frequency or call duration.
@@ -169,7 +171,8 @@ def sync_activities(ctx):
     start_date -= timedelta(seconds=offset_secs)
     # date_created__gt has precision to the second
     formatted_start = start_date.strftime("%Y-%m-%dT%H:%M:%S")
-    params = {"date_created__gt": formatted_start}
+    # Fetch data between formatted_start and end_date
+    params = {"date_created__gt": formatted_start, "date_created__lt": end_date}
     request = create_request(IDS.ACTIVITIES, params=params)
     paginated_sync(IDS.ACTIVITIES, ctx, request, formatted_start)
 

--- a/tests/unittests/test_closeio_request_has_end_date_in_params.py
+++ b/tests/unittests/test_closeio_request_has_end_date_in_params.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest import mock
+from tap_closeio import Context
+from tap_closeio.streams import sync_activities
+import datetime
+
+
+class TestAPIReuqestHasWidowBoundaryParams(unittest.TestCase):
+    @mock.patch('tap_closeio.streams.paginated_sync')
+    @mock.patch('tap_closeio.Context.update_start_date_bookmark', side_effect= lambda x: '2010-01-01')
+    @mock.patch('tap_closeio.streams.singer.utils.now', side_effect=lambda : datetime.datetime(2022, 4, 13))
+    @mock.patch('tap_closeio.streams.create_request')
+    def test_request_has_date_created__gt_and_date_created__lt(self, mocked_create_request, mocked_singer_utils_now, mocked_update_start_bookmark, mocked_paginated_sync):
+        """
+        To verify that create_request function params have date_created__gt and date_created__lt
+        """
+        ctx = Context({'start_date': "test", 'api_key': 'test'}, {})
+        params = {'date_created__gt': '2009-12-31T00:00:00', 'date_created__lt': '2022-04-13T00:00:00'}
+        sync_activities(ctx)
+        mocked_create_request.assert_called_with('activities', params=params)


### PR DESCRIPTION
# Description of change
 - Add date_created__lt as the current time in request params to ignore future values.
 - Add test case to check weather request accept date_created__lt or not

# Manual QA steps
 - Check that by adding date_created__lt in request params we get future data or not
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
