### PR TITLE
Update new_max_bookmark, Add unittests

### DIFF
--- a/tap_closeio/streams.py
+++ b/tap_closeio/streams.py
@@ -36,13 +36,14 @@ FORMATTERS = {
     IDS.LEADS: format_leads,
 }
 
+BOOKMARK_NOW = datetime.utcnow()
 
 def bookmark(tap_stream_id):
     return [tap_stream_id, BOOK_KEYS[tap_stream_id]]
 
 
 def new_max_bookmark(max_bookmark, records, key):
-    now = datetime.utcnow()
+    now = BOOKMARK_NOW
     max_bookmark = pendulum.parse(max_bookmark)
     for record in records:
         potential_bookmark = pendulum.parse(record[key])

--- a/tap_closeio/streams.py
+++ b/tap_closeio/streams.py
@@ -46,7 +46,7 @@ def new_max_bookmark(max_bookmark, records, key):
     max_bookmark = pendulum.parse(max_bookmark)
     for record in records:
         potential_bookmark = pendulum.parse(record[key])
-        if potential_bookmark > max_bookmark and potential_bookmark <= now:
+        if max_bookmark < potential_bookmark  and potential_bookmark <= now:
             max_bookmark = potential_bookmark
         elif potential_bookmark > now:
             LOGGER.info(f"Got future-dated bookmark value `{potential_bookmark}`; not updating state.")

--- a/tap_closeio/streams.py
+++ b/tap_closeio/streams.py
@@ -36,14 +36,14 @@ FORMATTERS = {
     IDS.LEADS: format_leads,
 }
 
-BOOKMARK_NOW = datetime.utcnow()
+SYNC_START = datetime.utcnow()
 
 def bookmark(tap_stream_id):
     return [tap_stream_id, BOOK_KEYS[tap_stream_id]]
 
 
 def new_max_bookmark(max_bookmark, records, key):
-    now = BOOKMARK_NOW
+    now = SYNC_START
     max_bookmark = pendulum.parse(max_bookmark)
     for record in records:
         potential_bookmark = pendulum.parse(record[key])
@@ -175,7 +175,7 @@ def sync_activities(ctx):
     try:
         # get date window from config
         date_window = int(ctx.config.get("date_window", 15))
-        # if date_window is 0, '0' or None, then set default window size of 15 days
+       # if date_window is 0, '0' or None, then set default window size of 15 days
         if not date_window:
             LOGGER.warning("Invalid value of date window is passed: \'{}\', using default window size of 15 days.".format(ctx.config.get("date_window")))
             date_window = 15
@@ -188,7 +188,7 @@ def sync_activities(ctx):
     start_date -= timedelta(seconds=offset_secs)
 
     window_start_date = start_date._datetime
-    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    now = SYNC_START.replace(tzinfo=timezone.utc)
     while window_start_date <= now:
         window_end_date = window_start_date + timedelta(days=date_window)
 
@@ -239,7 +239,7 @@ def sync_event_log(ctx):
     # > scan the latest five minutes of events.
     # Therefore we do not set the bookmark to any value that is in the last
     # five minutes.
-    now = datetime.utcnow().replace(tzinfo=timezone.utc)
+    now = SYNC_START.replace(tzinfo=timezone.utc)
     five_minutes_ago = strftime(now - timedelta(minutes=5))
     max_bookmark = min(five_minutes_ago, max_bookmark)
     ctx.set_bookmark(bookmark(IDS.EVENT_LOG), max_bookmark)


### PR DESCRIPTION
# Description of change
- Updates new_max_bookmark to check that we do not write future-dated bookmark values (as we've observed Closeio returning future-dated `activities` records even when passing the `date_created__lt` parameter on requests)
- Adds unittests

# Manual QA steps
 - added 2 unittests that validate new_max_bookmark functionality::
   - test_new_max_bookmark_valid_potential
   - test_new_max_bookmark_future_dated_potential
   
# Risks
 - Minimal. State is stored in the same format, but it will no longer have the potential to be a datetime string greater than now().
 
# Rollback steps
 - revert this branch
